### PR TITLE
EN-7102 Sync event_id.proto. Remove auctionid documentation comments.

### DIFF
--- a/beeswax/base/eventid.proto
+++ b/beeswax/base/eventid.proto
@@ -12,7 +12,6 @@ message EventId {
   // 32 bits of md5 hash
   optional uint32 hostid = 1;
   optional uint32 tid = 2;
-  // Thread Id from gettid()
   optional uint64 timestamp = 3;
   // Impression index within the request
   optional uint32 imp_idx = 4;

--- a/beeswax/base/eventid.proto
+++ b/beeswax/base/eventid.proto
@@ -12,6 +12,7 @@ message EventId {
   optional uint32 hostid = 1;    // 32 bits of md5 hash
   optional uint32 tid = 2;       // Thread Id from gettid()
   optional uint64 timestamp = 3;
+  optional uint32 imp_idx = 4; // Impression index within the request
 }
 
 // Next Tag: 5

--- a/beeswax/base/eventid.proto
+++ b/beeswax/base/eventid.proto
@@ -9,10 +9,13 @@ package base;
 option java_package = "com.beeswax.base";
 
 message EventId {
-  optional uint32 hostid = 1;    // 32 bits of md5 hash
-  optional uint32 tid = 2;       // Thread Id from gettid()
+  // 32 bits of md5 hash
+  optional uint32 hostid = 1;
+  optional uint32 tid = 2;
+  // Thread Id from gettid()
   optional uint64 timestamp = 3;
-  optional uint32 imp_idx = 4; // Impression index within the request
+  // Impression index within the request
+  optional uint32 imp_idx = 4;
 }
 
 // Next Tag: 5

--- a/beeswax/logs/ad_log.proto
+++ b/beeswax/logs/ad_log.proto
@@ -25,6 +25,9 @@ import "beeswax/openrtb/openrtb_common.proto";
 // Next Tag: 6
 // RequestLogMessage is created for every incoming bid request from the exchange.
 message RequestLogMessage {
+  // The unique identifier of the auction per buzz_key.
+  // There can be multiple impression definitions in a single bid request from the
+  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   optional openrtb.Enums.Inventory.Source inventory_source = 2;
   optional openrtb.BidRequest bidrequest = 3;
@@ -37,10 +40,15 @@ message RequestLogMessage {
 // Next Tag: 18
 // ImpressionLogMessage is created for every won auction.
 message ImpressionLogMessage {
+  // The unique identifier of the auction per buzz_key.
+  // There can be multiple impression definitions in a single bid request from the
+  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
   // of elements within it or on the format of the id.
   optional string auctionid_str = 12;
+  // The unique identifier of the bid request per buzz_key. This represents a BidRequest
+  // received from an inventory source, which can contain 1 or more impression definitions.
   optional string requestid_str = 17;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 10;
@@ -73,10 +81,15 @@ message ImpressionLogMessage {
 // Next Tag: 14
 // ClickLogMessage is created for clicks received.
 message ClickLogMessage {
+  // The unique identifier of the auction per buzz_key.
+  // There can be multiple impression definitions in a single bid request from the
+  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
   // of elements within it or on the format of the id.
   optional string auctionid_str = 9;
+  // The unique identifier of the bid request per buzz_key. This represents a BidRequest
+  // received from an inventory source, which can contain 1 or more impression definitions.
   optional string requestid_str = 13;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 7;
@@ -107,10 +120,15 @@ message ClickLogMessage {
 // ActivityLogMessage is created for video and activity events
 // like video "START", "SKIP", etc.
 message ActivityLogMessage {
+  // The unique identifier of the auction per buzz_key.
+  // There can be multiple impression definitions in a single bid request from the
+  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
   // of elements within it or on the format of the id.
   optional string auctionid_str = 10;
+  // The unique identifier of the bid request per buzz_key. This represents a BidRequest
+  // received from an inventory source, which can contain 1 or more impression definitions.
   optional string requestid_str = 13;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 8;

--- a/beeswax/logs/ad_log.proto
+++ b/beeswax/logs/ad_log.proto
@@ -34,13 +34,14 @@ message RequestLogMessage {
   optional bid.BidAgentResponse.AgentData agent_data = 5;
 }
 
-// Next Tag: 17
+// Next Tag: 18
 // ImpressionLogMessage is created for every won auction.
 message ImpressionLogMessage {
-  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
-  // of elements within it or the format of the id.
   optional base.EventId auctionid = 1;
+  // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
+  // of elements within it or on the format of the id.
   optional string auctionid_str = 12;
+  optional string requestid_str = 17;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 10;
   optional uint64 advertiser_id = 11;
@@ -69,13 +70,14 @@ message ImpressionLogMessage {
   optional string gdpr_consent_string = 15;
 }
 
-// Next Tag: 13
+// Next Tag: 14
 // ClickLogMessage is created for clicks received.
 message ClickLogMessage {
-  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
-  // of elements within it or the format of the id.
   optional base.EventId auctionid = 1;
+  // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
+  // of elements within it or on the format of the id.
   optional string auctionid_str = 9;
+  optional string requestid_str = 13;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 7;
   optional uint64 advertiser_id = 8;
@@ -101,14 +103,15 @@ message ClickLogMessage {
   optional bool is_gdpr = 12 [default = false];
 }
 
-// Next Tag: 13
+// Next Tag: 14
 // ActivityLogMessage is created for video and activity events
 // like video "START", "SKIP", etc.
 message ActivityLogMessage {
-  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
-  // of elements within it or the format of the id.
   optional base.EventId auctionid = 1;
+  // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
+  // of elements within it or on the format of the id.
   optional string auctionid_str = 10;
+  optional string requestid_str = 13;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 8;
   optional uint64 advertiser_id = 9;
@@ -184,8 +187,6 @@ message ConversionLogMessage {
   // Timestamp (usecs) at which event was received by Beeswax.
   optional uint64 rx_timestamp = 7;
   // auction id (Filled only for postback events)
-  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
-  // of elements within it or the format of the id.
   optional string auctionid = 8;
 
   // When this field is set to true, it implies that Beeswax has determined that

--- a/beeswax/logs/ad_log.proto
+++ b/beeswax/logs/ad_log.proto
@@ -37,9 +37,9 @@ message RequestLogMessage {
 // Next Tag: 17
 // ImpressionLogMessage is created for every won auction.
 message ImpressionLogMessage {
+  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
+  // of elements within it or the format of the id.
   optional base.EventId auctionid = 1;
-  // The unique identifier of the auction per buzz_key.
-  // Format: <auctionid.timestamp>.<auctionid.hostid>.<auctionid.tid>.<buzz_key>
   optional string auctionid_str = 12;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 10;
@@ -72,9 +72,9 @@ message ImpressionLogMessage {
 // Next Tag: 13
 // ClickLogMessage is created for clicks received.
 message ClickLogMessage {
+  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
+  // of elements within it or the format of the id.
   optional base.EventId auctionid = 1;
-  // The unique identifier of the auction per buzz_key.
-  // Format: <auctionid.timestamp>.<auctionid.hostid>.<auctionid.tid>.<buzz_key>
   optional string auctionid_str = 9;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 7;
@@ -105,9 +105,9 @@ message ClickLogMessage {
 // ActivityLogMessage is created for video and activity events
 // like video "START", "SKIP", etc.
 message ActivityLogMessage {
+  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
+  // of elements within it or the format of the id.
   optional base.EventId auctionid = 1;
-  // The unique identifier of the auction per buzz_key.
-  // Format: <auctionid.timestamp>.<auctionid.hostid>.<auctionid.tid>.<buzz_key>
   optional string auctionid_str = 10;
   optional base.AdGroupId adgroupid = 2;
   optional uint64 creative_id = 8;
@@ -184,6 +184,8 @@ message ConversionLogMessage {
   // Timestamp (usecs) at which event was received by Beeswax.
   optional uint64 rx_timestamp = 7;
   // auction id (Filled only for postback events)
+  // NOTE: auctionid is an opaque unique id. Client cannot rely on the meaning
+  // of elements within it or the format of the id.
   optional string auctionid = 8;
 
   // When this field is set to true, it implies that Beeswax has determined that

--- a/beeswax/logs/ad_log.proto
+++ b/beeswax/logs/ad_log.proto
@@ -27,7 +27,7 @@ import "beeswax/openrtb/openrtb_common.proto";
 message RequestLogMessage {
   // The unique identifier of the auction per buzz_key.
   // There can be multiple impression definitions in a single bid request from the
-  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
+  // inventory source; each one Beeswax actually bids on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   optional openrtb.Enums.Inventory.Source inventory_source = 2;
   optional openrtb.BidRequest bidrequest = 3;
@@ -42,7 +42,7 @@ message RequestLogMessage {
 message ImpressionLogMessage {
   // The unique identifier of the auction per buzz_key.
   // There can be multiple impression definitions in a single bid request from the
-  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
+  // inventory source; each one Beeswax actually bids on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
   // of elements within it or on the format of the id.
@@ -83,7 +83,7 @@ message ImpressionLogMessage {
 message ClickLogMessage {
   // The unique identifier of the auction per buzz_key.
   // There can be multiple impression definitions in a single bid request from the
-  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
+  // inventory source; each one Beeswax actually bids on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
   // of elements within it or on the format of the id.
@@ -122,7 +122,7 @@ message ClickLogMessage {
 message ActivityLogMessage {
   // The unique identifier of the auction per buzz_key.
   // There can be multiple impression definitions in a single bid request from the
-  // inventory source; each one Beeswax actually bidus on creates a unique auctionid.
+  // inventory source; each one Beeswax actually bids on creates a unique auctionid.
   optional base.EventId auctionid = 1;
   // NOTE: auction_id_str is an opaque unique id. Clients should not rely on the meaning
   // of elements within it or on the format of the id.


### PR DESCRIPTION
…public clients can parse elements of auctionid in a meaningful and stable way.