### PR TITLE
[FW-114062]Fix ad_log.proto by adding missing imports

### DIFF
--- a/beeswax/adgroup/vendor_fee.proto
+++ b/beeswax/adgroup/vendor_fee.proto
@@ -1,0 +1,32 @@
+// Copyright 2022, Beeswax.IO Inc.
+//
+// Protocol buffer defining vendor fees
+
+syntax = "proto2";
+package adgroup;
+
+import "beeswax/currency/currency.proto";
+
+option java_package = "com.beeswax.adgroup";
+option cc_enable_arenas = true;
+
+
+// VendorFeesInfo contains the aggregrated amount and percent of a
+// lineitem/campaign's vendor fees.
+// Next Id: 3
+message VendorFeesInfo {
+  // total_vendor_fees_transactions are grouped by currency.
+  // vendor fees with the same currency are aggregrated into one
+  // CurrencyAmount object.
+  // For example, if a lineitem/campaign has a vendor fees of 30 micros USD,
+  // another of 20 micros USD, the other 40 micros GBP,
+  // there will be two items in this field - one 50 micros USD,
+  // the other 40 micros GBP.
+  repeated currency.CurrencyAmount total_vendor_fees_amounts = 1;
+  // total_fee_percent_micros is the sum of percent value in micros of all
+  // percent type vendor fees.
+  // For example, a line/campaign has a vendor fees at 5%, another 2%,
+  // this field will be "7" in micros, i.e., 7000000
+  optional int64 total_fee_percent_micros = 2;
+}
+

--- a/beeswax/logs/streaming/ad_log.proto
+++ b/beeswax/logs/streaming/ad_log.proto
@@ -15,12 +15,14 @@ package logs;
 
 option java_package = "com.beeswax.logs";
 
+import "beeswax/adgroup/vendor_fee.proto";
 import "beeswax/bid/adcandidate.proto";
 import "beeswax/bid/request.proto";
 import "beeswax/base/eventid.proto";
 import "beeswax/currency/currency.proto";
 import "beeswax/openrtb/openrtb.proto";
 import "beeswax/openrtb/openrtb_common.proto";
+import "beeswax/stinger/adgroup.proto";
 
 // Next Tag: 6
 // RequestLogMessage is created for every incoming bid request from the exchange.

--- a/beeswax/stinger/adgroup.proto
+++ b/beeswax/stinger/adgroup.proto
@@ -1,0 +1,60 @@
+// Copyright 2022, Beeswax.IO Inc.
+//
+// Protocol buffer defining BidShadingInfo
+
+syntax = "proto2";
+package stinger;
+
+option java_package = "com.beeswax.stinger";
+
+// Next Tag: 3
+message BidShadingFee {
+    enum BidShadingFeeType {
+      UNKNOWN = 0;
+      // 1. A BidShadingFee will be VENDOR_FEE type if the Seat the customer belongs to is CUSTOMER_BILLABLE.
+      // 2. The lineitem will have a VendorFee object representing the bid shading fee.
+      // 3. The bid shading fee (as a vendor fee) will be included in
+      //    budget_fees.total_cpm_type_vendor_fees_usd_micros if the budget type is "2" (budget_fees.include_vendor_fees is True)
+      // 4. The bid shading fee will be included in the budget system's spend amount if the budget type of the lineitem is "2"
+      //    (budget_fees.include_vendor_fees is True).
+      // 5. media_spend will NOT contain the bid shading fee.
+      // 6. The bid shading fee will show up in impression_details table and win log's as `bid_shading_fee_micros_usd`.
+      VENDOR_FEE = 1;
+      // 1. A BidShadingFee will be INCLUDED_IN_WINPRICE type if the Seat the customer belongs to is BEESWAX_BILLABLE
+      // 2. Honeypot-event will include the bid shading fee (as an additional fee amount) into impression_event.win_cost_micros_usd.
+      // 3. media_spend (calculated by waggle) will contain the bid shading fee.
+      // 4. The bid shading fee will be included in the budget system's spend regardless of the budget type.
+      // 5. The bid shading fee will show up in impression_details table and win log's as `bid_shading_fee_micros_usd`.
+      INCLUDED_IN_WINPRICE = 2;
+    }
+  
+    optional BidShadingFeeType bid_shading_fee_type = 1;
+    optional int64 bid_shading_fee_micros_usd = 2;
+  }
+
+// Information about bid shading like what group the event is in
+// and what slice the request belongs to
+// Next Tag: 6
+message BidShadingInfo {
+    enum BidGroup {
+      UNKNOWN = 0;
+      CONTROL = 1;
+      TEST = 2;
+    }
+  
+    enum BidShadeState {
+      NOT_ELIGIBLE = 0;
+      CONTROL_GROUP = 1;
+      BID_SHADED = 2;
+      RANDOM = 3;
+  
+    }
+    optional BidGroup bid_group = 1 [default=UNKNOWN];
+    optional string slice_id = 2;
+    // state of bid shading
+    optional BidShadeState bid_shade = 3 [default=NOT_ELIGIBLE];
+    // micros we reduced the customer's bid price by.
+    optional int64 bid_shade_reduction_micros = 4;
+    optional BidShadingFee bid_shading_fee = 5;
+  }
+  

--- a/beeswax/stinger/adgroup.proto
+++ b/beeswax/stinger/adgroup.proto
@@ -11,20 +11,7 @@ option java_package = "com.beeswax.stinger";
 message BidShadingFee {
     enum BidShadingFeeType {
       UNKNOWN = 0;
-      // 1. A BidShadingFee will be VENDOR_FEE type if the Seat the customer belongs to is CUSTOMER_BILLABLE.
-      // 2. The lineitem will have a VendorFee object representing the bid shading fee.
-      // 3. The bid shading fee (as a vendor fee) will be included in
-      //    budget_fees.total_cpm_type_vendor_fees_usd_micros if the budget type is "2" (budget_fees.include_vendor_fees is True)
-      // 4. The bid shading fee will be included in the budget system's spend amount if the budget type of the lineitem is "2"
-      //    (budget_fees.include_vendor_fees is True).
-      // 5. media_spend will NOT contain the bid shading fee.
-      // 6. The bid shading fee will show up in impression_details table and win log's as `bid_shading_fee_micros_usd`.
       VENDOR_FEE = 1;
-      // 1. A BidShadingFee will be INCLUDED_IN_WINPRICE type if the Seat the customer belongs to is BEESWAX_BILLABLE
-      // 2. Honeypot-event will include the bid shading fee (as an additional fee amount) into impression_event.win_cost_micros_usd.
-      // 3. media_spend (calculated by waggle) will contain the bid shading fee.
-      // 4. The bid shading fee will be included in the budget system's spend regardless of the budget type.
-      // 5. The bid shading fee will show up in impression_details table and win log's as `bid_shading_fee_micros_usd`.
       INCLUDED_IN_WINPRICE = 2;
     }
   


### PR DESCRIPTION
- Added the missing message definition bid_shading_info. ad_log.proto file can be compiled successfully now
- Remove two commits with sensitive data from the git history
- Added the missing message VendorFeesInfo after removing two commits with sensitive data. 