### PR TITLE
[FW-164647]: Deprecate old adx fields

### DIFF
--- a/beeswax/openrtb/extension.proto
+++ b/beeswax/openrtb/extension.proto
@@ -460,6 +460,7 @@ message SamsungNativeExtension {
 message AdxGeoExtension {
   optional int32 dma_region_code = 1;
   // Use fes.exchange.adx.AdxBidRequest.HyperlocalSet to parse.
+  // DEPRECATED. Will be fully removed 08/2024.
   optional bytes hyperlocal_set = 2 [deprecated = true];
 }
 

--- a/beeswax/openrtb/extension.proto
+++ b/beeswax/openrtb/extension.proto
@@ -460,7 +460,7 @@ message SamsungNativeExtension {
 message AdxGeoExtension {
   optional int32 dma_region_code = 1;
   // Use fes.exchange.adx.AdxBidRequest.HyperlocalSet to parse.
-  optional bytes hyperlocal_set = 2;
+  optional bytes hyperlocal_set = 2 [deprecated = true];
 }
 
 // 2. AppNexus Exchange

--- a/beeswax/openrtb/openrtb.proto
+++ b/beeswax/openrtb/openrtb.proto
@@ -1599,7 +1599,7 @@ message NativeRequest {
         // Exchange-specific values above 500.
 
         // STORE bit for ADX NativeAdTemplate
-        STORE = 500;
+        STORE = 500 [deprecated = true];
       }
     }
   }

--- a/beeswax/openrtb/openrtb.proto
+++ b/beeswax/openrtb/openrtb.proto
@@ -1599,6 +1599,7 @@ message NativeRequest {
         // Exchange-specific values above 500.
 
         // STORE bit for ADX NativeAdTemplate
+        // DEPRECATED. Will be fully removed 08/2024.
         STORE = 500 [deprecated = true];
       }
     }


### PR DESCRIPTION
We have moved from the adx proto version 135 to 297, which removed the corresponding fields. We no longer have use for these fields in our openrtb proto.